### PR TITLE
Fixing squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/VisitorConfig.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/VisitorConfig.java
@@ -51,9 +51,9 @@ public enum VisitorConfig {
     public static VisitorConfig get(boolean fields, boolean methods, VisitorConfig defaultConfig) {
         if (fields && methods) {
             return VisitorConfig.ALL;
-        } else if (fields && !methods) {
+        } else if (fields) {
             return VisitorConfig.FIELDS_ONLY;
-        } else if (methods && !fields) {
+        } else if (methods) {
             return VisitorConfig.METHODS_ONLY;
         } else {
             return defaultConfig;

--- a/querydsl-sql/src/main/java/com/querydsl/sql/teradata/SetQueryBandClause.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/teradata/SetQueryBandClause.java
@@ -124,7 +124,7 @@ public class SetQueryBandClause extends AbstractSQLClause<SetQueryBandClause> {
                         + (forSession ? "' for session" : "' for transaction");
                 parameter = null;
             } else {
-                queryString = "set query_band=?" + (forSession ? " for session" : " for transaction");
+                queryString = "set query_band=? for transaction";
                 parameter = builder.toString();
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583
Please let me know if you have any questions.
Kirill Vlasov
